### PR TITLE
Add Bayesian regression example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Readme
+
+This repository contains an example Python script demonstrating a simple Bayesian linear regression model built with PyMC3. See `bayesian_regression.py` for details.

--- a/bayesian_regression.py
+++ b/bayesian_regression.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pymc3 as pm
+import matplotlib.pyplot as plt
+
+np.random.seed(123)
+X = np.linspace(0, 1, 20)
+true_slope = 2.5
+true_intercept = 1.0
+sigma = 0.5
+y = true_intercept + true_slope * X + np.random.normal(0, sigma, size=len(X))
+
+with pm.Model() as model:
+    alpha = pm.Normal('alpha', mu=0, sigma=10)
+    beta = pm.Normal('beta', mu=0, sigma=10)
+    epsilon = pm.HalfCauchy('epsilon', beta=5)
+
+    mu = alpha + beta * X
+    y_obs = pm.Normal('y_obs', mu=mu, sigma=epsilon, observed=y)
+
+    trace = pm.sample(2000, tune=1000, cores=1, progressbar=False)
+
+pm.summary(trace).round(2)
+
+# Plot posterior distributions
+pm.plot_posterior(trace, var_names=['alpha', 'beta'])
+plt.show()


### PR DESCRIPTION
## Summary
- add a simple Bayesian linear regression script using PyMC3
- document the new example in README

## Testing
- `python3 -m py_compile bayesian_regression.py`


------
https://chatgpt.com/codex/tasks/task_e_6843e98039fc8320981337c5de253156